### PR TITLE
Fix vertical normalisation when mapping glyphs.

### DIFF
--- a/bmfont-json.lisp
+++ b/bmfont-json.lisp
@@ -37,7 +37,8 @@
        ;; should be singleton nodes
        (assert (not (getf *font* k)))
        (setf (getf *font* k) atts)
-       (when (eq k :common)
+       (when (and (eq k :common)
+                  (null (getf *font* :pages)))
          (setf (getf *font* :pages)
                (make-array (getf atts :pages)
                            :fill-pointer 0))))

--- a/bmfont.lisp
+++ b/bmfont.lisp
@@ -57,14 +57,12 @@
                                    :if-exists :supersede)
          (funcall wf font f))))))
 
-
-(defun map-glyphs (font function string &key y-up)
+(defun map-glyphs (font function string &key model-y-up texture-y-up)
   (loop with w = (float (scale-w font))
         with h = (float (scale-h font))
-        with y = (if y-up
-                     (- (base font))
-                     (base font))
+        with y = 0
         with x = 0
+        with line = (line-height font)
         with space = (or (getf (gethash #\space (chars font)) :xadvance)
                          ;; try to guess a good 'space' size if font
                          ;; doesn't have space char
@@ -85,9 +83,7 @@
            (case c
              (#\newline
               (setf x 0)
-              (incf y (if y-up
-                          (- (line-height font))
-                          (line-height font))))
+              (incf y line))
              (#\space
               (incf x space))
              (#\tab
@@ -95,22 +91,21 @@
               (incf x (* 8 space)))
              (t
               (incf x k)
-              (funcall function
-                       (+ x (getf char :xoffset))
-                       (if y-up
-                           (+ y (- (getf char :yoffset))
-                              (- (getf char :height)))
-                           (+ y (getf char :yoffset)))
-                       (+ x (getf char :xoffset)
-                          (getf char :width))
-                       (if y-up
-                           (+ y (- (getf char :yoffset)))
-                           (+ y (getf char :yoffset) (getf char :height)))
-                       (/ (getf char :x) w) (/ (getf char :y) h)
-                       (/ (+ (getf char :x) (getf char :width))
-                          w)
-                       (/ (+ (getf char :y) (getf char :height))
-                          h))
+              (let ((x- (+ x (getf char :xoffset)))
+                    (y- (+ y (getf char :yoffset)))
+                    (x+ (+ x (getf char :xoffset) (getf char :width)))
+                    (y+ (+ y (getf char :yoffset) (getf char :height)))
+                    (u- (/ (getf char :x) w))
+                    (v- (/ (getf char :y) h))
+                    (u+ (/ (+ (getf char :x) (getf char :width)) w))
+                    (v+ (/ (+ (getf char :y) (getf char :height)) h)))
+                (when model-y-up
+                  (psetf y- (- line y+)
+                         y+ (- line y-)))
+                (when texture-y-up
+                  (psetf v- (- 1 v+)
+                         v+ (- 1 v-)))
+                (funcall function x- y- x+ y+ u- v- u+ v+))
               (incf x (getf char :xadvance))))))
 
 

--- a/bmfont.lisp
+++ b/bmfont.lisp
@@ -57,7 +57,7 @@
                                    :if-exists :supersede)
          (funcall wf font f))))))
 
-(defun map-glyphs (font function string &key model-y-up texture-y-up)
+(defun map-glyphs (font function string &key model-y-up texture-y-up start end)
   (loop with w = (float (scale-w font))
         with h = (float (scale-h font))
         with y = 0
@@ -72,7 +72,8 @@
                                   sum (or (getf c :xadvance) 0))
                             (float (hash-table-count (chars font)))))
         for p = nil then c
-        for c across string
+        for i from (or start 0) below (or end (length string))
+        for c = (aref string i)
         for char = (or (gethash c (chars font))
                        (gethash :invalid (chars font))
                        (list :xoffset 0 :yoffset 0 :x 0 :y 0

--- a/package.lisp
+++ b/package.lisp
@@ -82,4 +82,5 @@
            #:red-chnl
            #:green-chnl
            #:blue-chnl
-           #:map-glyphs))
+           #:map-glyphs
+           #:measure-glyphs))


### PR DESCRIPTION
Specifically, we introduce two options for controlling the vertical increase behaviour:

  MODEL-Y-UP   --- To be used for systems where the geometry origin is in the lower left corner.
  TEXTURE-Y-UP --- To be used for systems where the texture origin is in the lower left corner.

In either case text will logically grow downwards with new lines, with the first line being anchored
at the baseline.